### PR TITLE
Fix URL prefix being ignored

### DIFF
--- a/dash_cognito_auth/cognito_oauth.py
+++ b/dash_cognito_auth/cognito_oauth.py
@@ -1,4 +1,5 @@
 from oauthlib.oauth2.rfc6749.errors import InvalidGrantError, TokenExpiredError
+from dash import Dash
 from flask import (
     redirect,
     url_for,
@@ -15,7 +16,7 @@ class CognitoOAuth(Auth):
     Wraps a Dash App and adds Cognito based OAuth2 authentication.
     """
 
-    def __init__(self, app, domain, region, additional_scopes=None):
+    def __init__(self, app: Dash, domain, region, additional_scopes=None):
         super(CognitoOAuth, self).__init__(app)
         cognito_bp = make_cognito_blueprint(
             domain=domain,
@@ -27,7 +28,10 @@ class CognitoOAuth(Auth):
             ]
             + (additional_scopes if additional_scopes else []),
         )
-        app.server.register_blueprint(cognito_bp, url_prefix="/login")
+
+        dash_base_path = app.get_relative_path("")
+
+        app.server.register_blueprint(cognito_bp, url_prefix=f"{dash_base_path}/login")
 
     def is_authorized(self):
         if not cognito.authorized:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,8 @@
+"""
+Shared test fixtures.
+"""
+
+# pylint: disable=W0621
 from unittest.mock import patch
 
 import pytest
@@ -38,6 +43,45 @@ def app_with_auth(app) -> CognitoOAuth:
     - App Client Id: testclient
     - App Client Secret: testsecret
     """
+
+    auth = CognitoOAuth(app, domain="test", region="eu-central-1")
+    auth.app.server.config["COGNITO_OAUTH_CLIENT_ID"] = "testclient"
+    auth.app.server.config["COGNITO_OAUTH_CLIENT_SCRET"] = "testsecret"
+
+    return auth
+
+
+@pytest.fixture
+def app_with_url_prefix(name="dash") -> Dash:
+    """
+    Dash App that has only one H1 Tag with the value "Hello World".
+    It uses a Flask server with the secret key just_a_test.
+
+    All URLs should be prefixed with /some/prefix/
+    """
+
+    dash_app = Dash(name, server=Flask(name), url_base_pathname="/some/prefix/")
+    dash_app.layout = html.H1("Hello World")
+    dash_app.server.config.update(
+        {
+            "TESTING": True,
+        }
+    )
+    dash_app.server.secret_key = "just_a_test"
+    return dash_app
+
+
+@pytest.fixture
+def prefixed_app_with_auth(app_with_url_prefix) -> CognitoOAuth:
+    """
+    Dash App wrapped with Cognito Authentication:
+    - Domain name: test
+    - Region: eu-central-1
+    - App Client Id: testclient
+    - App Client Secret: testsecret
+    """
+
+    app = app_with_url_prefix
 
     auth = CognitoOAuth(app, domain="test", region="eu-central-1")
     auth.app.server.config["COGNITO_OAUTH_CLIENT_ID"] = "testclient"

--- a/tests/test_auth_flows.py
+++ b/tests/test_auth_flows.py
@@ -31,6 +31,26 @@ def test_that_a_redirect_to_cognito_handler_happens_if_not_logged_in(
     assert response.headers.get("Location") == "/login/cognito"
 
 
+def test_that_a_redirect_to_cognito_handler_happens_if_not_logged_in_with_url_prefix(
+    prefixed_app_with_auth: CognitoOAuth,
+):
+    """
+    If we're not logged in, an unauthenticated request should result in a redirect
+    to the local cognito endpoint. This should respect any url_base_pathname settings.
+    """
+
+    # Arrange
+    flask_server: Flask = prefixed_app_with_auth.app.server
+    client = flask_server.test_client()
+
+    # Act
+    response = client.get("/some/prefix/")
+
+    # Assert
+    assert response.status_code == HTTPStatus.FOUND
+    assert response.headers.get("Location") == "/some/prefix/login/cognito"
+
+
 def test_that_cognito_handler_redirects_to_user_pool_if_not_authenticated(
     app_with_auth: CognitoOAuth,
 ):


### PR DESCRIPTION
- Add test that detects bug
- Fix fspijkerman/dash-cognito-auth/issues/9 by adding Dash's relative URL as a prefix to `/login` in the blueprint and thereby all paths