### PR TITLE
Add support for custom domains and clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,3 @@ COGNITO_REGION=<aws-region-of-the-cognito-userpool>
 COGNITO_OAUTH_CLIENT_ID=<app-client-id>
 COGNITO_OAUTH_CLIENT_SECRET=<app-client-secret>
 ```
-
-## Known Limitations
-
-- Fully Custom Cognito Domains aren't supported at the moment

--- a/dash_cognito_auth/auth.py
+++ b/dash_cognito_auth/auth.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from abc import ABCMeta, abstractmethod
 from six import iteritems, add_metaclass
 
@@ -7,24 +6,25 @@ from six import iteritems, add_metaclass
 class Auth(object):
     def __init__(self, app):
         self.app = app
-        self._index_view_name = app.config['routes_pathname_prefix']
+        self._index_view_name = app.config["routes_pathname_prefix"]
         self._overwrite_index()
         self._protect_views()
-        self._index_view_name = app.config['routes_pathname_prefix']
+        self._index_view_name = app.config["routes_pathname_prefix"]
 
     def _overwrite_index(self):
         original_index = self.app.server.view_functions[self._index_view_name]
 
-        self.app.server.view_functions[self._index_view_name] = \
-            self.index_auth_wrapper(original_index)
+        self.app.server.view_functions[self._index_view_name] = self.index_auth_wrapper(
+            original_index
+        )
 
     def _protect_views(self):
         # require auth wrapper for all views
-        for view_name, view_method in iteritems(
-                self.app.server.view_functions):
+        for view_name, view_method in iteritems(self.app.server.view_functions):
             if view_name != self._index_view_name:
-                self.app.server.view_functions[view_name] = \
-                    self.auth_wrapper(view_method)
+                self.app.server.view_functions[view_name] = self.auth_wrapper(
+                    view_method
+                )
 
     @abstractmethod
     def is_authorized(self):

--- a/dash_cognito_auth/cognito_oauth.py
+++ b/dash_cognito_auth/cognito_oauth.py
@@ -16,8 +16,35 @@ class CognitoOAuth(Auth):
     Wraps a Dash App and adds Cognito based OAuth2 authentication.
     """
 
-    def __init__(self, app: Dash, domain, region, additional_scopes=None):
-        super(CognitoOAuth, self).__init__(app)
+    def __init__(self, app: Dash, domain: str, region=None, additional_scopes=None):
+        """
+        Wrap a Dash App with Cognito authentication.
+
+        The app needs two configuration options to work:
+
+        COGNITO_OAUTH_CLIENT_ID -> Client-ID of the Cognito App Client
+        COGNITO_OAUTH_CLIENT_SECRET -> Secret of the Cognito App Client
+
+        Can be set like this:
+
+        app.server.config["COGNITO_OAUTH_CLIENT_ID"] = "something"
+        app.server.config["COGNITO_OAUTH_CLIENT_SECRET"] = "something"
+
+        ---
+
+        Parameters
+        ----------
+        app : Dash
+            The app to add authentication to.
+        domain : str
+            Either the domain prefix of the User Pool domain if hosted by Cognito
+            or the FQDN of your custom domain, e.g. authentication.example.com
+        region : str, optional
+            AWS region of the User Pool. Mandatory if domain is NOT a custom domain, by default None
+        additional_scopes : Additional OAuth Scopes to request, optional
+            By default openid, email, and profile are requested - default value: None
+        """
+        super().__init__(app)
         cognito_bp = make_cognito_blueprint(
             domain=domain,
             region=region,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 setup(
     name="dash-cognito-auth",
     description="Dash Cognito Auth",
-    long_description=open("README.md", "rt").read().strip(),
+    long_description=open("README.md", "rt", encoding="utf-8").read().strip(),
     long_description_content_type="text/markdown",
     author="Frank Spijkerman",
     author_email="frank@jeito.nl",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ Shared test fixtures.
 """
 
 # pylint: disable=W0621
+from typing import Iterator
 from unittest.mock import patch
 
 import pytest
@@ -91,7 +92,23 @@ def prefixed_app_with_auth(app_with_url_prefix) -> CognitoOAuth:
 
 
 @pytest.fixture
-def authorized_app(app) -> CognitoOAuth:
+def app_with_auth_and_cognito_custom_domain(app) -> CognitoOAuth:
+    """
+    Dash App wrapped with Cognito Authentication
+    - Domain name authentication.example.com
+    - App Client Id: testclient
+    - App Client Secret: testsecret
+    """
+
+    auth = CognitoOAuth(app, domain="authentication.example.com")
+    auth.app.server.config["COGNITO_OAUTH_CLIENT_ID"] = "testclient"
+    auth.app.server.config["COGNITO_OAUTH_CLIENT_SCRET"] = "testsecret"
+
+    return auth
+
+
+@pytest.fixture
+def authorized_app(app) -> Iterator[CognitoOAuth]:
     """
     App with Cognito Based authentication that bypasses the authentication/authorization
     part, i.e. replaced is_authorized and the authorized endpoint.

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -4,6 +4,8 @@ Integration test that authenticates against a real user pool.
 Naturally these are a bit sensitive to the way the Cognito UI is implemented.
 """
 
+# pylint: disable=W0621
+
 import os
 
 from http import HTTPStatus

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -2,6 +2,7 @@
 Test Dash Cognito Auth.
 """
 
+import pytest
 from dash_cognito_auth import CognitoOAuth
 
 
@@ -11,3 +12,16 @@ def test_init(app):
     auth = CognitoOAuth(app, domain="test", region="eu-west-1")
 
     assert auth.app is app
+
+
+def test_that_init_raises_an_exception_if_cognito_domain_and_region_is_missing(app):
+    """
+    Initializing the app with a Cognito Domain (non-FQDN) and no Region should
+    raise a ValueError.
+    """
+
+    # Arrange
+
+    # Act + Assert
+    with pytest.raises(ValueError):
+        CognitoOAuth(app, "non-fqdn")


### PR DESCRIPTION
- Add fspijkerman/dash-cognito-auth/issues/6
  - Removed unused default value for region in dash_cognito_auth.cognito.make_cognito_blueprint
  - Make region parameter optional (default: None) in dash_cognito_auth.cognito_oauth.CognitoOAuth constructor
  - Add tests for new functionality
- Add docstring to CognitoOAuth constructor
- Make pylint a little less nervous
- Remove some Python 2 compatibility imports as we're targeting >= 3.10